### PR TITLE
Added checking for optional data

### DIFF
--- a/commands/cve_feed.js
+++ b/commands/cve_feed.js
@@ -53,34 +53,47 @@ function generateMessage(d) {
   let out = `${b("Feed:")} ${"CVE (www.cve.circl.lu)"}\n\n`;
   out += `${b("Name:")} ${c(d.id)}\n\n`;
   out += `${b("Modified:")} ${c(new Date(d.Modified).toUTCString())}\n`;
-  out += `${b("Published:")} ${c(new Date(d.Published))}\n\n`;
+  out += `${b("Published:")} ${c(new Date(d.Published).toUTCString())}\n\n`;
 
-  if (d.access.authentication)
+  if (d.access?.authentication)
     out += `${b("Authentication:")} ${c(d.access.authentication)}\n`;
-  if (d.access.complexity)
+  if (d.access?.complexity)
     out += `${b("Complexity:")} ${c(d.access.complexity)}\n`;
-  if (d.access.vector) out += `${b("Vector:")} ${c(d.access.vector)}\n`;
+  if (d.access?.vector) out += `${b("Vector:")} ${c(d.access.vector)}\n`;
 
-  out += `${b("Assigner:")} ${d.assigner}\n\n`;
+  if (d.assigner) out += `${b("Assigner:")} ${d.assigner}\n\n`;
 
-  out += `${b("Summary:")} ${d.summary}\n\n`;
+  if (d.summary) out += `${b("Summary:")} ${d.summary}\n\n`;
 
-  out += `${b("Ref. Links:")}\n${d.references.join("\n").trim()}\n\n`;
+  if (d.references && d.references.length > 0)
+    out += `${b("Ref. Links:")}\n${d.references.join("\n").trim()}\n\n`;
 
-  out += `${b("Availability:")} ${c(d.impact.availability)}\n`;
-  out += `${b("Confidentiality:")} ${c(d.impact.confidentiality)}\n`;
-  out += `${b("Integrity:")} ${c(d.impact.integrity)}\n\n`;
-
-  if (d.vulnerable_configuration)
-    out += `${b("Vulnerable Configuration(s):")} ${c(
-      d.vulnerable_configuration.join("\n")
+  if (d.vulnerable_configuration && d.vulnerable_configuration.length > 0)
+    out += `${b("Vulnerable Configuration(s):")}\n${c(
+      d.vulnerable_configuration
+        .map((v) => {
+          return v
+            .split(":")
+            .slice(3)
+            .filter((v) => v != "*")
+            .join(" ");
+        })
+        .join("\n")
     ).trim()}\n`;
-  if (d.vulnerable_product)
-    out += `${b("Vulnerable Product(s):")} ${c(
-      d.vulnerable_product.join("\n")
+  if (d.vulnerable_product && d.vulnerable_product.length > 0)
+    out += `${b("Vulnerable Product(s):")}\n${c(
+      d.vulnerable_product
+        .map((v) => {
+          return v
+            .split(":")
+            .slice(3)
+            .filter((v) => v != "*")
+            .join(" ");
+        })
+        .join("\n")
     ).trim()}`;
 
-  return out;
+  return out.trim();
 }
 
 /**
@@ -93,7 +106,7 @@ async function getLastFeed() {
   let data_old = fs.readFileSync(resCmd("data_cve.txt")).toString();
 
   if (+newTimestamp != data_old) {
-    fs.writeFileSync(resCmd("data_cve.txt"), +(new Date(data.Modified)) + "");
+    fs.writeFileSync(resCmd("data_cve.txt"), +new Date(data.Modified) + "");
     return data;
   }
   return null;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "dotenv": "^9.0.2",
-    "fs": "^0.0.1-security",
+    "fs": "0.0.2",
     "ms": "^2.1.3",
     "path": "^0.12.7",
     "rss-to-json": "^2.0.2",


### PR DESCRIPTION
`Vulnerable configurations` and `Vulnerable products` may sometimes be empty: remove them if so
`Vulnerable configurations` and `Vulnerable products` added formatting: `cpe:2.3:a:ivanti:neurons_for_itsm:2023.4:*:*:*:*:*:*:*` will now appear as `ivanti:neurons_for_itsm:2023.4` skipping the cpe tag, cpe version and cpe data type (a,o,h)
Removed `Availability`, `Confidentiality` and `Integrity` as they are no longer provided by cve.circl.lu